### PR TITLE
Add AWS CloudFormation generator and CI/CD workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+name: CI/CD
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION || 'us-east-1' }}
+      LAMBDA_S3_BUCKET: ${{ secrets.LAMBDA_S3_BUCKET }}
+      LAMBDA_S3_KEY: ${{ secrets.LAMBDA_S3_KEY }}
+      CLOUDFRONT_ORIGIN_DOMAIN: ${{ secrets.CLOUDFRONT_ORIGIN_DOMAIN }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install backend dependencies
+        run: |
+          cd backend
+          python -m pip install -r requirements.txt
+
+      - name: Compile backend
+        run: python -m py_compile backend/*.py
+
+      - name: Install frontend dependencies
+        run: |
+          cd web
+          npm install
+          npm run type-check
+
+      - name: Generate CloudFormation template
+        run: |
+          python iac/generate_template.py > template.yml
+
+      - name: Deploy CloudFormation stack
+        run: |
+          aws cloudformation deploy --template-file template.yml --stack-name call-assistant
+

--- a/README.md
+++ b/README.md
@@ -71,3 +71,8 @@ The system uses PostgreSQL with the following main entities:
 ## API Documentation
 
 Once the backend is running, visit `http://localhost:8000/docs` for interactive API documentation. 
+## Deployment
+
+The `iac/generate_template.py` script creates an AWS CloudFormation template for deploying the backend Lambda function and a CloudFront distribution for the frontend. The workflow defined in `.github/workflows/deploy.yml` runs on pushes to `main`, executes basic tests, generates the template and deploys it using the AWS credentials stored in GitHub secrets.
+
+Required secrets include `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `LAMBDA_S3_BUCKET`, `LAMBDA_S3_KEY` and `CLOUDFRONT_ORIGIN_DOMAIN`.

--- a/iac/generate_template.py
+++ b/iac/generate_template.py
@@ -1,0 +1,56 @@
+import os
+
+
+def generate_cloudformation():
+    bucket = os.environ.get("LAMBDA_S3_BUCKET", "my-bucket")
+    key = os.environ.get("LAMBDA_S3_KEY", "lambda.zip")
+    handler = os.environ.get("LAMBDA_HANDLER", "main.handler")
+    runtime = os.environ.get("LAMBDA_RUNTIME", "python3.10")
+    origin = os.environ.get("CLOUDFRONT_ORIGIN_DOMAIN", "example.com")
+
+    template = f"""
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Call Assistant Deployment
+Resources:
+  BackendFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: {handler}
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Runtime: {runtime}
+      Code:
+        S3Bucket: {bucket}
+        S3Key: {key}
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+  FrontendDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        Origins:
+          - Id: frontend
+            DomainName: {origin}
+            CustomOriginConfig:
+              OriginProtocolPolicy: https-only
+        DefaultCacheBehavior:
+          TargetOriginId: frontend
+          ViewerProtocolPolicy: redirect-to-https
+          AllowedMethods: [GET, HEAD, OPTIONS]
+          CachedMethods: [GET, HEAD]
+"""
+    return template
+
+
+if __name__ == "__main__":
+    print(generate_cloudformation())


### PR DESCRIPTION
## Summary
- add Python script that outputs a CloudFormation template for the Lambda backend and CloudFront
- document deployment process and required secrets
- add GitHub Actions workflow to build, test and deploy using the generated template

## Testing
- `python3 -m py_compile backend/*.py`
- `python iac/generate_template.py | head`
- `npm install` *(fails: blocked by network)*

------
https://chatgpt.com/codex/tasks/task_e_68603278e300832aa3a0d31b248be693