### PR TITLE
Fix dependency conflict in backend requirements

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,7 +11,6 @@ passlib[bcrypt]==1.7.4
 python-multipart==0.0.6
 twilio==8.10.3
 openai==1.3.6
-openai-agents[voice]
 sounddevice==0.4.6
 numpy
 asyncio-mqtt==0.16.1


### PR DESCRIPTION
## Summary
- remove unused `openai-agents` dependency from backend

## Testing
- `pytest -q`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603b49e598832aba43a40f23db9295