### PR TITLE
Improve CF failure diagnostics

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,8 +81,16 @@ jobs:
             FrontendS3Bucket=${{ secrets.FRONTEND_S3_BUCKET }} \
           --capabilities CAPABILITY_IAM \
           --no-fail-on-empty-changeset
-        
+
         echo "✅ CloudFormation deployment completed"
+
+    - name: Fetch CloudFormation failure events
+      if: failure()
+      run: |
+        echo "❌ Stack deployment failed. Fetching recent events..."
+        aws cloudformation describe-stack-events \
+          --stack-name ${{ env.STACK_NAME }} \
+          --max-items 20 || echo "Unable to fetch stack events"
 
     - name: Get deployment outputs
       run: |


### PR DESCRIPTION
## Summary
- extend deployment workflow to log CloudFormation events when `aws cloudformation deploy` fails

## Testing
- `python -m py_compile iac/generate_template.py`
- `python iac/generate_template.py > /tmp/test_template.yml`

------
https://chatgpt.com/codex/tasks/task_e_6860a169d798832a9de97efd53fada8f